### PR TITLE
Add LGUI+RGUI binding for "hyper" combo

### DIFF
--- a/firmware/boards/shields/nyx/nyx.keymap
+++ b/firmware/boards/shields/nyx/nyx.keymap
@@ -83,12 +83,18 @@
         combo_upperl {
             timeout-ms = <50>;
             key-positions = <56 57>;
-            bindings = <&mo UPPER>;
+            bindings = <&mo UPPER>; // LGUI+FN
         };
         combo_upperr {
             timeout-ms = <50>;
-            key-positions = <62 63>;
+            key-positions = <62 63>; // RGUI+FN
             bindings = <&mo UPPER>;
         };
+        // Fake "hyper" key for macOS window management and such.
+        combo_hyper {
+            timeout_ms = <50>;
+            key-positions = <56 63>; // LGUI+RGUI
+            bindings = <&kp LGUI &kp LCTRL &kp LALT>;
+        }
     };
 };


### PR DESCRIPTION
Trying to make non-clashing combos for macOS window managers (Yabai, Hammerspoon).